### PR TITLE
docs(skills): consolidate issue and pr skill groups

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: issue
+description: >-
+  Grouped issue workflow for creating, reading, and refining GitHub issues.
+  Routes to create, read, or refine instructions based on user intent.
+---
+
+# Issue Skills
+
+Detect the user's intent, then read and follow the matching sub-instruction file.
+
+| Intent | Common trigger phrases | File |
+|--------|------------------------|------|
+| Create issue | create issue, file issue, open issue, draft issue | `create.md` |
+| Read issue | read issue, issue 4, #4, quick issue assessment | `read.md` |
+| Refine issue | refine issue, investigate issue, clarify issue, update issue, upload plan | `refine.md` |
+
+## How to route
+
+1. Match the request to one intent in the table above.
+2. Read the corresponding file from this directory.
+3. Follow that file exactly.
+
+## Guardrails
+
+- Ask follow-up questions when intent is ambiguous.
+- Do not mix actions; route to one primary action first.
+- If the user asks for multiple actions, handle them sequentially.

--- a/.agents/skills/issue/create.md
+++ b/.agents/skills/issue/create.md
@@ -1,16 +1,9 @@
----
-name: issue-create
-description: >-
-  Conversationally drafts and creates a GitHub issue using repo templates.
-  Use when the user asks to create, file, or open an issue.
----
-
 # Issue Create
 
 ## Goal
 
 Guide the user from a rough idea to a well-structured GitHub issue through
-natural conversation — understand first, structure later.
+natural conversation -- understand first, structure later.
 
 ## Flow
 
@@ -20,23 +13,23 @@ This is a **multi-turn conversational** skill. Do NOT rush to templates.
 
 Ask the user briefly:
 - What do you want to work on, or what's the problem?
-- Keep it open-ended — one or two questions max.
+- Keep it open-ended -- one or two questions max.
 
 ### Phase 2: Discuss and explore (turns 2-3)
 
 Based on the user's answer:
 
-1. **Codebase scan** — search for relevant files, packages, entry points
+1. **Codebase scan** -- search for relevant files, packages, entry points
    related to what the user described. Present findings concisely.
-2. **Ask clarifying questions** — dig into specifics:
+2. **Ask clarifying questions** -- dig into specifics:
    - Scope and impact area
    - Expected behavior vs actual behavior (if a bug)
    - Why it matters / motivation (if a feature)
    - Any known constraints or dependencies
-3. **Share observations** — flag related code, existing TODOs, similar
+3. **Share observations** -- flag related code, existing TODOs, similar
    patterns, or potential risks found during the scan.
 
-Keep the conversation natural. Don't interrogate — collaborate.
+Keep the conversation natural. Don't interrogate -- collaborate.
 
 ### Phase 3: Match to template (after 2-3 turns of discussion)
 
@@ -112,7 +105,7 @@ Print the created issue URL.
 ## Guardrails
 
 - **Never create without explicit user approval.**
-- Do not fetch templates until Phase 3 — understand the problem first.
+- Do not fetch templates until Phase 3 -- understand the problem first.
 - Do not invent content; everything comes from the conversation.
-- Do not skip required template fields — prompt the user if gaps remain.
+- Do not skip required template fields -- prompt the user if gaps remain.
 - Preserve the template's section order in the output.

--- a/.agents/skills/issue/read.md
+++ b/.agents/skills/issue/read.md
@@ -1,12 +1,3 @@
----
-name: issue-read
-description: >-
-  Reads a GitHub issue and produces a quick context brief with scope, impact
-  areas, risks, and open questions. Use when the user mentions an issue
-  reference like "issue 4", "#4", "read issue", or asks for a quick issue
-  assessment.
----
-
 # Issue Read
 
 ## Goal
@@ -47,7 +38,7 @@ URL: <url>
 - <apps/services/packages paths>
 
 ### Risk level
-- <low|medium|high> — <one-line rationale>
+- <low|medium|high> -- <one-line rationale>
 
 ### Open questions
 - <missing requirements or ambiguities>

--- a/.agents/skills/issue/refine.md
+++ b/.agents/skills/issue/refine.md
@@ -1,17 +1,9 @@
----
-name: issue-refine
-description: >-
-  Investigates, clarifies, or updates a GitHub issue. Use when the user asks
-  to refine, investigate, clarify, spec out, or update an issue, or wants to
-  upload a plan or findings to an issue.
----
-
 # Issue Refine
 
 ## Goal
 
 Improve issue clarity or update it with new information. This skill is
-flexible and user-driven — it responds to what you ask.
+flexible and user-driven -- it responds to what you ask.
 
 ## Common Actions
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pr
+description: >-
+  Grouped pull request workflow for creating PRs and fixing PR review comments.
+  Routes to create or comment-fix instructions based on user intent.
+---
+
+# PR Skills
+
+Detect the user's intent, then read and follow the matching sub-instruction file.
+
+| Intent | Common trigger phrases | File |
+|--------|------------------------|------|
+| Create PR | create PR, open pull request, submit for review | `create.md` |
+| Fix PR comments | fix PR comments, address review feedback, resolve PR suggestions | `comment-fix.md` |
+
+## How to route
+
+1. Match the request to one intent in the table above.
+2. Read the corresponding file from this directory.
+3. Follow that file exactly.
+
+## Guardrails
+
+- Ask follow-up questions when intent is ambiguous.
+- Do not mix actions; route to one primary action first.
+- If the user asks for multiple actions, handle them sequentially.

--- a/.agents/skills/pr/comment-fix.md
+++ b/.agents/skills/pr/comment-fix.md
@@ -1,13 +1,3 @@
----
-name: pr-comment-fix
-description: >-
-  Read PR review comments and propose or apply fixes. Fetches inline review
-  comments and top-level reviews from a GitHub PR, summarises actionable
-  feedback, then edits the affected files. Use when the user asks to fix PR
-  comments, address review feedback, resolve PR suggestions, or mentions
-  "pr-comment-fix".
----
-
 # PR Comment Fix
 
 ## Goal
@@ -46,8 +36,8 @@ Derive `{owner}/{repo}` from `gh repo view --json nameWithOwner -q .nameWithOwne
 For each inline comment extract:
 - **File path** (`path`) and **line** (`line` / `original_line`)
 - **Author** and whether it is a bot
-- **Severity** — look for P0/P1/P2 badges; otherwise infer from language
-- **Action** — what the reviewer wants changed
+- **Severity** -- look for P0/P1/P2 badges; otherwise infer from language
+- **Action** -- what the reviewer wants changed
 
 Filter out:
 - Boilerplate blocks (e.g. `<details>` "About Codex" sections)
@@ -59,7 +49,7 @@ Filter out:
 Show the user a numbered list:
 
 ```
-## PR #<N> — Review Feedback
+## PR #<N> -- Review Feedback
 
 ### 1. (P1) `path/to/file.ts:42`
 Author: reviewer
@@ -108,6 +98,6 @@ gh api repos/{owner}/{repo}/pulls/<N>/comments/<comment_id>/replies \
 ## Guardrails
 
 - Always confirm with the user before applying changes.
-- Do not fabricate reviewer intent — if a comment is ambiguous, flag it.
+- Do not fabricate reviewer intent -- if a comment is ambiguous, flag it.
 - Skip bot boilerplate and resolved threads automatically.
 - Follow the repo's coding style and commit conventions.

--- a/.agents/skills/pr/create.md
+++ b/.agents/skills/pr/create.md
@@ -1,8 +1,3 @@
----
-name: pr-create
-description: Create GitHub pull requests using the gh CLI. Detects the base branch of the current branch, confirms it with the user, and populates the PR body from the repo's .github/pull_request_template.md. Use when the user asks to create a PR, open a pull request, or submit changes for review.
----
-
 # Create Pull Request
 
 ## Workflow
@@ -99,7 +94,7 @@ EOF
 )"
 ```
 
-**Title format**: Follow the repo's commit convention — `type(scope): summary` (e.g., `feat(web): add user profile page`).
+**Title format**: Follow the repo's commit convention -- `type(scope): summary` (e.g., `feat(web): add user profile page`).
 
 ### Step 8: Return the PR URL
 

--- a/platform/.cursor/skills/issue
+++ b/platform/.cursor/skills/issue
@@ -1,0 +1,1 @@
+../../../.agents/skills/issue

--- a/platform/.cursor/skills/issue-create
+++ b/platform/.cursor/skills/issue-create
@@ -1,1 +1,0 @@
-../../../.agents/skills/issue-create

--- a/platform/.cursor/skills/issue-read
+++ b/platform/.cursor/skills/issue-read
@@ -1,1 +1,0 @@
-../../../.agents/skills/issue-read

--- a/platform/.cursor/skills/issue-refine
+++ b/platform/.cursor/skills/issue-refine
@@ -1,1 +1,0 @@
-../../../.agents/skills/issue-refine

--- a/platform/.cursor/skills/pr
+++ b/platform/.cursor/skills/pr
@@ -1,0 +1,1 @@
+../../../.agents/skills/pr

--- a/platform/.cursor/skills/pr-comment-fix
+++ b/platform/.cursor/skills/pr-comment-fix
@@ -1,1 +1,0 @@
-../../../.agents/skills/pr-comment-fix

--- a/platform/.cursor/skills/pr-create
+++ b/platform/.cursor/skills/pr-create
@@ -1,1 +1,0 @@
-../../../.agents/skills/pr-create


### PR DESCRIPTION
# Resolves #16

Consolidates five standalone issue/PR skills into two grouped routers (`issue`, `pr`) to reduce context-window noise and simplify skill discovery.

## Proposed Changes
- [x] Merged `issue-create`, `issue-read`, and `issue-refine` into `.agents/skills/issue/` with a router `SKILL.md`
- [x] Merged `pr-create` and `pr-comment-fix` into `.agents/skills/pr/` with a router `SKILL.md`
- [x] Updated `platform/.cursor/skills/` symlinks to point to `issue` and `pr`
- [x] Removed old `issue-*` and `pr-*` skill symlinks
- [x] Left `plan`, `commit`, and `sync-with-template` unchanged

## Demo
N/A

## Test Plan
- Verified the new skill layout exists under `.agents/skills/issue/` and `.agents/skills/pr/`
- Verified symlink targets:
  - `platform/.cursor/skills/issue -> ../../../.agents/skills/issue`
  - `platform/.cursor/skills/pr -> ../../../.agents/skills/pr`
- Attempted required checks, but local environment blocked execution:
  - `CI=1 pnpm test:unit` (script not defined at workspace root)
  - `pnpm typecheck` and `pnpm format:write` failed due to `turbo` permission denied

Made with [Cursor](https://cursor.com)